### PR TITLE
Set a default healthcheck path based on path pattern

### DIFF
--- a/services/main.tf
+++ b/services/main.tf
@@ -1,3 +1,9 @@
+locals {
+  default_healthcheck_path  = "/management/healthcheck"
+  fallback_healthcheck_path = "${replace(var.path_pattern, "/*", local.default_healthcheck_path)}"
+  healthcheck_path          = "${var.healthcheck_path == "" ? local.fallback_healthcheck_path : var.healthcheck_path}"
+}
+
 module "service" {
   source              = "./ecs_service"
   service_name        = "${var.name}"
@@ -11,7 +17,7 @@ module "service" {
   path_pattern        = "${var.path_pattern}"
   alb_priority        = "${var.alb_priority}"
   desired_count       = "${var.desired_count}"
-  healthcheck_path    = "${var.healthcheck_path}"
+  healthcheck_path    = "${local.healthcheck_path}"
   infra_bucket        = "${var.infra_bucket}"
   host_name           = "${var.host_name}"
 

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -82,8 +82,8 @@ variable "path_pattern" {
 }
 
 variable "healthcheck_path" {
-  description = "path for ECS healthcheck endpoint"
-  default     = "/management/healthcheck"
+  description = "Path for ECS healthcheck endpoint.  Defaults to /management/healthcheck."
+  default     = ""
 }
 
 variable "infra_bucket" {


### PR DESCRIPTION
If the caller doesn't supply an explicit path pattern, we add `/management/healthcheck` to their ALB path pattern and use that instead. One less line to write in the caller config.