### PR TITLE
Make log_group_name_prefix variable

### DIFF
--- a/ecs_script_task/cloudwatch.tf
+++ b/ecs_script_task/cloudwatch.tf
@@ -1,3 +1,3 @@
 resource "aws_cloudwatch_log_group" "task" {
-  name = "platform/${var.task_name}"
+  name = "${var.log_group_name_prefix}/${var.task_name}"
 }

--- a/ecs_script_task/variables.tf
+++ b/ecs_script_task/variables.tf
@@ -50,3 +50,8 @@ variable "name" {
   description = "Name of container in task description"
   default     = "app"
 }
+
+variable "log_group_name_prefix" {
+  description = "Cloudwatch log group name prexix"
+  default     = "platform"
+}

--- a/services/ecs_tasks/cloudwatch.tf
+++ b/services/ecs_tasks/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_group" "task" {
-  name = "platform/${var.task_name}"
+  name = "${var.log_group_name_prefix}/${var.task_name}"
 }
 
 resource "aws_cloudwatch_log_group" "nginx_task" {
-  name = "platform/nginx_${var.task_name}"
+  name = "${var.log_group_name_prefix}/nginx_${var.task_name}"
 }

--- a/services/ecs_tasks/variables.tf
+++ b/services/ecs_tasks/variables.tf
@@ -67,3 +67,7 @@ variable "memory" {
 variable "cpu" {
   description = "How much CPU to allocate to the app"
 }
+
+variable "log_group_name_prefix" {
+  description = "Cloudwatch log group name prexix"
+}

--- a/services/variables.tf
+++ b/services/variables.tf
@@ -161,3 +161,8 @@ variable "config_template_path" {
 variable "https_domain" {
   default = ""
 }
+
+variable "log_group_name_prefix" {
+  description = "Cloudwatch log group name prexix"
+  default     = "platform"
+}

--- a/userdata/cloudwatch.tf
+++ b/userdata/cloudwatch.tf
@@ -1,3 +1,3 @@
 resource "aws_cloudwatch_log_group" "ecs_agent" {
-  name = "platform/ecs-agent-${var.cluster_name}"
+  name = "${var.log_group_name_prefix}/ecs-agent-${var.cluster_name}"
 }

--- a/userdata/variables.tf
+++ b/userdata/variables.tf
@@ -27,3 +27,8 @@ variable "ebs_cache_max_age_days" {
 variable "ebs_cache_max_size" {
   default = ""
 }
+
+variable "log_group_name_prefix" {
+  description = "Cloudwatch log group name prexix"
+  default     = "platform"
+}


### PR DESCRIPTION
Don't enforce `platform` prefix on Cloudwatch log group names.