### PR TITLE
Remove uk.ac.wellcome namespace from ECR repo

### DIFF
--- a/ecr/repository.tf
+++ b/ecr/repository.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "repository" {
-  name = "uk.ac.wellcome/${var.name}"
+  name = "${var.namespace}/${var.id}"
 
   lifecycle {
     prevent_destroy = true

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -1,3 +1,7 @@
-variable "name" {
-  description = "Name of the ECR repository"
+variable "id" {
+  description = "ID of the ECR repository"
+}
+
+variable "namespace" {
+  description = "Namespace prefix to ECR repository"
 }


### PR DESCRIPTION
In order to make that module more reusable.

