### PR TITLE
Adds Worker Service module

### DIFF
--- a/worker_service/README.md
+++ b/worker_service/README.md
@@ -1,0 +1,47 @@
+# Worker Service
+
+This module provides a high level abstraction on top of the services module.
+
+A worker service consists of:
+
+- SQS queue for ingesting units of work.
+- An ECS service.
+- Autoscaling rules to scale up the service when there is work to be done.
+- SNS topic for exporting completed work.
+
+The consumer needs to provide an application container that reads from SQS processes work and outputs results to SNS.
+
+## Usage
+
+You can instantiate a worker service module as follows:
+
+```tf
+module "example_worker_service" {
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs_iam?ref=worker_service"
+
+  name = "my_worker_service"
+
+  ingest_topic_name = "my_ingest_topic"
+
+  cluster_name = "my_ecs_cluster"
+  infra_bucket = "my_infra_bucket"
+
+  vpc_id = "vpc-id"
+
+  listener_https_arn = "${var.listener_https_arn}"
+  listener_http_arn  = "${var.listener_http_arn}"
+
+  alb_client_error_alarm_arn = "${var.alb_client_error_alarm_arn}"
+  alb_server_error_alarm_arn = "${var.alb_server_error_alarm_arn}"
+
+  loadbalancer_cloudwatch_id = "${var.loadbalancer_cloudwatch_id}"
+  dlq_alarm_arn              = "${var.dlq_alarm_arn}"
+
+  https_domain = "services.example.com"
+}
+
+```
+
+### Chaining Workers
+
+Workers can be chained together by using the `export_topic_name` output as the input to another worker service.

--- a/worker_service/autoscaling.tf
+++ b/worker_service/autoscaling.tf
@@ -1,0 +1,17 @@
+module "worker_service_appautoscaling" {
+  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/app/ecs?ref=v1.1.0"
+  name   = "${var.name}"
+
+  cluster_name = "${var.cluster_name}"
+  service_name = "${module.worker_service.service_name}"
+}
+
+module "worker_service_sqs_autoscaling_alarms" {
+  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/alarms/sqs?ref=v1.1.0"
+  name   = "${var.name}"
+
+  queue_name = "${module.worker_service_ingest_queue.name}"
+
+  scale_up_arn   = "${module.worker_service_appautoscaling.scale_up_arn}"
+  scale_down_arn = "${module.worker_service_appautoscaling.scale_down_arn}"
+}

--- a/worker_service/data.tf
+++ b/worker_service/data.tf
@@ -1,0 +1,5 @@
+data "aws_ecs_cluster" "host_cluster" {
+  cluster_name = "${var.cluster_name}"
+}
+
+data "aws_caller_identity" "current" {}

--- a/worker_service/export_topic.tf
+++ b/worker_service/export_topic.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "worker_service_export_topic" {
+  name = "${var.name}"
+}

--- a/worker_service/iam.tf
+++ b/worker_service/iam.tf
@@ -1,0 +1,45 @@
+module "ecs_worker_service_iam" {
+  source = "git::https://github.com/wellcometrust/terraform.git//ecs_iam?ref=v1.0.0"
+  name   = "id_minter"
+}
+
+resource "aws_iam_role_policy" "ecs_worker_service_task_sns" {
+  name   = "ecs_task_task_sns_policy"
+  role   = "${module.ecs_worker_service_iam.task_role_name}"
+  policy = "${data.aws_iam_policy_document.publish_to_topic.json}"
+}
+
+resource "aws_iam_role_policy" "ecs_worker_service_task_read_id_minter_q" {
+  name   = "ecs_task_worker_service_policy"
+  role   = "${module.ecs_worker_service_iam.task_role_name}"
+  policy = "${module.worker_service_ingest_queue.read_policy}"
+}
+
+resource "aws_iam_role_policy" "worker_service_cloudwatch" {
+  role   = "${module.ecs_worker_service_iam.task_role_name}"
+  policy = "${data.aws_iam_policy_document.allow_cloudwatch_push_metrics.json}"
+}
+
+data "aws_iam_policy_document" "allow_cloudwatch_push_metrics" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "publish_to_topic" {
+  statement {
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      "${aws_sns_topic.worker_service_export_topic.arn}",
+    ]
+  }
+}

--- a/worker_service/ingest_queue.tf
+++ b/worker_service/ingest_queue.tf
@@ -1,0 +1,9 @@
+module "worker_service_ingest_queue" {
+  source      = "git::https://github.com/wellcometrust/terraform.git//sqs?ref=v1.1.0"
+  queue_name  = "${var.name}_queue"
+  aws_region  = "${var.aws_region}"
+  account_id  = "${data.aws_caller_identity.current.account_id}"
+  topic_names = ["${var.ingest_topic_name}"]
+
+  alarm_topic_arn = "${var.dlq_alarm_arn}"
+}

--- a/worker_service/locals.tf
+++ b/worker_service/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  ingest_queue_config = "${map("worker_service_ingest_queue", module.worker_service_ingest_queue.id)}"
+  export_topic_config = "${map("worker_service_export_topic", aws_sns_topic.worker_service_export_topic.arn)}"
+
+  metrics_namespace_config = "${map("metrics_namespace", var.name)}"
+}

--- a/worker_service/main.tf
+++ b/worker_service/main.tf
@@ -1,0 +1,30 @@
+module "worker_service" {
+  source             = "git::https://github.com/wellcometrust/terraform.git//services?ref=v1.3.1"
+  name               = "${var.name}"
+  cluster_id         = "${data.aws_ecs_cluster.host_cluster.id}"
+  task_role_arn      = "${module.ecs_worker_service_iam.task_role_arn}"
+  vpc_id             = "${var.vpc_id}"
+  app_uri            = "${var.app_container_repo_uri}"
+  listener_https_arn = "${var.listener_https_arn}"
+  listener_http_arn  = "${var.listener_http_arn}"
+  path_pattern       = "/${var.name}/*"
+  alb_priority       = "${var.alb_priority}"
+  infra_bucket       = "${var.infra_bucket}"
+
+  config_key           = "config/${var.build_env}/${var.name}.ini"
+  config_template_path = "config/${var.name}.ini.template"
+
+  cpu    = "${var.service_cpu}"
+  memory = "${var.service_memory}"
+
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
+
+  config_vars = "${merge(local.export_topic_config, local.ingest_queue_config, local.metrics_namespace_config, var.config_vars)}"
+
+  loadbalancer_cloudwatch_id   = "${var.loadbalancer_cloudwatch_id}"
+  server_error_alarm_topic_arn = "${var.alb_server_error_alarm_arn}"
+  client_error_alarm_topic_arn = "${var.alb_client_error_alarm_arn}"
+
+  https_domain = "${var.https_domain}"
+}

--- a/worker_service/outputs.tf
+++ b/worker_service/outputs.tf
@@ -1,0 +1,4 @@
+output "export_topic_name" {
+  description = "Name of the export SNS topic"
+  value       = "${aws_sns_topic.worker_service_export_topic.name}"
+}

--- a/worker_service/variables.tf
+++ b/worker_service/variables.tf
@@ -1,0 +1,97 @@
+variable "name" {
+  description = "The name of this worker service"
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster in which this service is deployed."
+}
+
+variable "vpc_id" {
+  description = "The id of the VPC in which the worker service runs."
+}
+
+variable "ingest_topic_name" {
+  description = "The name of the SNS topic to subscribe the ingest queue to."
+}
+
+variable "dlq_alarm_arn" {
+  description = "Alarm of the ARN which the ingest DLQ should alert on."
+}
+
+variable "listener_https_arn" {
+  description = "HTTPS listener ARN from ALB"
+}
+
+variable "listener_http_arn" {
+  description = "HTTP listener ARN from ALB"
+}
+
+variable "infra_bucket" {
+  description = "The name of the S3 bucket used to store infrastructure config."
+}
+
+variable "loadbalancer_cloudwatch_id" {
+  description = "Cloudwatch ID for the ALB."
+}
+
+variable "alb_server_error_alarm_arn" {
+  description = "Alarm of the ARN used to report server errors."
+}
+
+variable "alb_client_error_alarm_arn" {
+  description = "Alarm of the ARN used to report client errors."
+}
+
+variable "https_domain" {
+  description = "HTTPS domain the ALB is running in."
+}
+
+variable "config_vars" {
+  description = "Variables for the config template"
+  type        = "map"
+  default     = {}
+}
+
+variable "alb_priority" {
+  description = "ALB priority for service"
+  default     = "100"
+}
+
+variable "service_cpu" {
+  description = "CPU to provide task"
+  default     = 256
+}
+
+variable "service_memory" {
+  description = "Memory to provide task"
+  default     = 1024
+}
+
+variable "aws_region" {
+  description = "The AWS region to create things in."
+  default     = "eu-west-1"
+}
+
+variable "release_id" {
+  description = "The specific release of the worker service to deploy."
+  default     = "latest"
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Minimum % of tasks running"
+  default     = "0"
+}
+
+variable "deployment_maximum_percent" {
+  description = "Maximum % of tasks running"
+  default     = "200"
+}
+
+variable "build_env" {
+  description = "The build environment (used to find config in infra_bucket)."
+  default     = "prod"
+}
+
+variable "app_container_repo_uri" {
+  description = "ECR repository URL"
+}


### PR DESCRIPTION
This module provides a high level abstraction on top of the services module.

A worker service consists of:

- SQS queue for ingesting units of work.
- An ECS service.
- Autoscaling rules to scale up the service when there is work to be done.
- SNS topic for exporting completed work.

The consumer needs to provide an application container that reads from SQS processes work and outputs results to SNS.

## Usage

You can instantiate a worker service module as follows:

```tf
module "example_worker_service" {
  source = "git::https://github.com/wellcometrust/terraform.git//ecs_iam?ref=worker_service"

  name = "my_worker_service"

  ingest_topic_name = "my_ingest_topic"

  cluster_name = "my_ecs_cluster"
  infra_bucket = "my_infra_bucket"

  vpc_id = "vpc-id"

  listener_https_arn = "${var.listener_https_arn}"
  listener_http_arn  = "${var.listener_http_arn}"

  alb_client_error_alarm_arn = "${var.alb_client_error_alarm_arn}"
  alb_server_error_alarm_arn = "${var.alb_server_error_alarm_arn}"

  loadbalancer_cloudwatch_id = "${var.loadbalancer_cloudwatch_id}"
  dlq_alarm_arn              = "${var.dlq_alarm_arn}"

  https_domain = "services.example.com"
}

```