### PR TITLE
healthcheck_path default docs to reflect the truth

### DIFF
--- a/service/variables.tf
+++ b/service/variables.tf
@@ -73,7 +73,7 @@ variable "path_pattern" {
 }
 
 variable "healthcheck_path" {
-  description = "Path for ECS healthcheck endpoint.  Defaults to /management/healthcheck."
+  description = "Path for ECS healthcheck endpoint.  Defaults to replace(var.path_pattern, "/*", "/healthcheck/path")."
   default     = ""
 }
 

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -73,7 +73,7 @@ variable "path_pattern" {
 }
 
 variable "healthcheck_path" {
-  description = "Path for ECS healthcheck endpoint.  Defaults to replace(var.path_pattern, "/*", "/healthcheck/path")."
+  description = "Path for ECS healthcheck endpoint.  Defaults to path_pattern.replace('/*', '/managment/healthcheck')."
   default     = ""
 }
 


### PR DESCRIPTION
The docs here are wrong.
I wasn't sure why this was the default (quite hard to figure out) - but at least now the docs reflect it.