### PR TITLE
Make the environment variables length a static variable

### DIFF
--- a/service/ecs_task/data.tf
+++ b/service/ecs_task/data.tf
@@ -72,7 +72,7 @@ data "aws_iam_role" "task_role" {
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
-  count    = "${length(local.env_vars)}"
+  count    = "${var.env_vars_length}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/service/ecs_task/data.tf
+++ b/service/ecs_task/data.tf
@@ -72,7 +72,7 @@ data "aws_iam_role" "task_role" {
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
-  count    = "${var.config_vars_length}"
+  count    = "${var.config_vars_length + length(var.service_vars)}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/service/ecs_task/data.tf
+++ b/service/ecs_task/data.tf
@@ -72,7 +72,7 @@ data "aws_iam_role" "task_role" {
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
-  count    = "${var.env_vars_length}"
+  count    = "${var.config_vars_length}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/service/ecs_task/variables.tf
+++ b/service/ecs_task/variables.tf
@@ -56,6 +56,8 @@ variable "config_vars" {
   type        = "map"
 }
 
+variable "config_var_length" {}
+
 variable "memory" {
   description = "How much memory to allocate to the app"
 }

--- a/service/ecs_task/variables.tf
+++ b/service/ecs_task/variables.tf
@@ -56,7 +56,7 @@ variable "config_vars" {
   type        = "map"
 }
 
-variable "config_var_length" {}
+variable "config_vars_length" {}
 
 variable "memory" {
   description = "How much memory to allocate to the app"

--- a/service/main.tf
+++ b/service/main.tf
@@ -53,8 +53,8 @@ module "task" {
     NGINX_PORT   = "${var.primary_container_port}"
   }
 
-  config_vars       = "${var.env_vars}"
-  config_var_length = "${var.env_vars_length}"
+  config_vars        = "${var.env_vars}"
+  config_vars_length = "${var.env_vars_length}"
 
   log_group_name_prefix = "${var.log_group_name_prefix}"
 }

--- a/service/main.tf
+++ b/service/main.tf
@@ -53,7 +53,8 @@ module "task" {
     NGINX_PORT   = "${var.primary_container_port}"
   }
 
-  config_vars = "${var.env_vars}"
+  config_vars       = "${var.env_vars}"
+  config_var_length = "${var.env_vars_length}"
 
   log_group_name_prefix = "${var.log_group_name_prefix}"
 }

--- a/service/variables.tf
+++ b/service/variables.tf
@@ -88,6 +88,8 @@ variable "env_vars" {
   default     = {}
 }
 
+variable "env_vars_length" {}
+
 variable "host_name" {
   description = "Hostname to be matched in the host condition"
   default     = ""

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -41,7 +41,8 @@ module "service" {
   deployment_minimum_healthy_percent = "0"
   deployment_maximum_percent         = "200"
 
-  env_vars = "${var.env_vars}"
+  env_vars        = "${var.env_vars}"
+  env_vars_length = "${var.env_vars_length}"
 
   loadbalancer_cloudwatch_id   = "${var.alb_cloudwatch_id}"
   server_error_alarm_topic_arn = "${var.alb_server_error_alarm_arn}"

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -21,7 +21,7 @@ data "aws_ecs_cluster" "cluster" {
 }
 
 module "service" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//service?ref=v4.0.0"
+  source = "git::https://github.com/wellcometrust/terraform-modules.git//service?ref=env_vars_length"
   name   = "${var.name}"
 
   cluster_id = "${data.aws_ecs_cluster.cluster.arn}"

--- a/sqs_autoscaling_service/variables.tf
+++ b/sqs_autoscaling_service/variables.tf
@@ -19,6 +19,8 @@ variable "env_vars" {
   type        = "map"
 }
 
+variable "env_vars_length" {}
+
 variable "alb_priority" {}
 variable "alb_listener_https_arn" {}
 variable "alb_listener_http_arn" {}


### PR DESCRIPTION
This works around a weirdness in Terraform’s interpolation abilities. Yes, it sucks, but it seems to work in the sierra_adapter stack, and I don’t want to fiddle any more with this.