### PR TITLE
Terrible fix for the autoscaling whack-a-mole

### DIFF
--- a/autoscaling/app/ecs/main.tf
+++ b/autoscaling/app/ecs/main.tf
@@ -49,5 +49,6 @@ resource "aws_appautoscaling_target" "service_scale_target" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["resource_id", "role_arn"]
   }
 }

--- a/autoscaling/app/ecs/main.tf
+++ b/autoscaling/app/ecs/main.tf
@@ -49,6 +49,23 @@ resource "aws_appautoscaling_target" "service_scale_target" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["resource_id", "role_arn"]
+
+    # This is an attempt to work around a bug we saw where autoscaling targets
+    # were continually deleted and recreated, but getting a complete set of
+    # working autoscale targets was a bit of a "whack-a-mole" process.
+    #
+    # We'd see the resource get recreated continually like so:
+    #
+    # -/+ aws_appautoscaling_target.service_scale_target (new resource required)
+    #       id:                 "service/cluster/name" => <computed> (forces new resource)
+    #       max_capacity:       "3" => "3"
+    #       min_capacity:       "0" => "0"
+    #       resource_id:        "service/cluster/name" => "service/cluster/name"
+    #       role_arn:           "arn:aws:iam::1234567890:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService" => "arn:aws:iam::1234567890:role/name_ecsAutoscaleRole" (forces new resource)
+    #       scalable_dimension: "ecs:service:DesiredCount" => "ecs:service:DesiredCount"
+    #       service_namespace:  "ecs" => "ecs"
+    #
+    # So this is a hacky fix to stop it being perpetually recreated!
+    ignore_changes = ["resource_id", "role_arn"]
   }
 }

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -1,5 +1,5 @@
 module "appautoscaling" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//autoscaling/app/ecs?ref=v5.0.2"
+  source = "../autoscaling/app/ecs?ref=v5.0.2"
   name   = "${var.name}"
 
   cluster_name = "${var.cluster_name}"


### PR DESCRIPTION
This is tested and applied in the Sierra stack; it stops our autoscaling targets being continually recreated.