### PR TITLE
Don't ignore the desired count on services

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: major
+
+Instances of the `ecs/service` module no longer ignore changes to the
+`desired_count` parameter.  Practically speaking, that means you can edit the
+parameter in Terraform and those changes will stick, rather than having to
+adjust the desired count in a separate process.

--- a/ecs/service/ecs_service/ecs.tf
+++ b/ecs/service/ecs_service/ecs.tf
@@ -15,16 +15,15 @@ resource "aws_ecs_service" "service" {
   }
 
   lifecycle {
-    ignore_changes = [
-      "desired_count",
-    ]
-
-    //    Unfortunately, when changing a service, this prevents the creation of the service with
-    //    InvalidParameterException: Creation of service was not idempotent.
-    //    Rename the service or delete this line if you get this error
-    //    Note: DELETING THIS LINE WILL RESULT IN DOWNTIME
-    //    See https://github.com/hashicorp/terraform/issues/12665 and
-    //    https://github.com/terraform-providers/terraform-provider-aws/issues/605
+    # Unfortunately, when changing a service, this prevents the creation of the
+    # service with the error:
+    #
+    #     InvalidParameterException: Creation of service was not idempotent.
+    #
+    # Rename the service or delete this line if you get this error
+    # Note: DELETING THIS LINE WILL RESULT IN DOWNTIME
+    # See https://github.com/hashicorp/terraform/issues/12665 and
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/605
     create_before_destroy = true
   }
 


### PR DESCRIPTION
This represents a major change in the way we do services, but I think it’s justified.

* Our public-facing services (API and Loris) have a statically defined size. This means we can define their size entirely in Terraform, and it will actually update!

* Most of our pipeline services (ingestor, ID minter, adapters) are queue-backed, and use our autoscaling modules. If the size of one of these services is temporarily reduced to zero, autoscaling quickly picks it back up again.

* The reindexer is the one problem here, but since reindexes are (relatively) rare, I think it’s better to push this weirdness out of Terraform and rely on us spotting when we’ve accidentally stopped the reindexer mid-reindex. (Note: this is much easier than fixing https://github.com/wellcometrust/platform/issues/1317!)

  Additionally, breaking up our Terraform into separate stacks means we’re touching the reindexer less often.

This change would allow us to delete a bunch of machinery from https://github.com/wellcometrust/platform/pull/1316, and drastically simplify switching our API pins.