### PR TITLE
Make the ALB alarms a bit less chatty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 jobs:
   include:
-    - env: TASK=check-format
+    - env: TASK=travis-format
     - env: TASK=check-release-file
     - env: TASK=deploy
       stage: deploy

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ format:
 check-format: format
 	git diff --exit-code
 
+travis-format:
+	python _scripts/run_travis_format.py
+
 check-release-file:
 	python _scripts/check-release-file.py
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ check-format: format
 	git diff --exit-code
 
 travis-format:
-	python _scripts/run_travis_format.py
+	python3 _scripts/run_travis_format.py
 
 check-release-file:
-	python _scripts/check-release-file.py
+	python3 _scripts/check-release-file.py
 
 deploy:
-	python _scripts/deploy.py
+	python3 _scripts/deploy.py

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 RELEASE_TYPE: patch
 
-This fixes a bug in the ALB alarms introduced in v6.1.0.
+This fixes a bug in the ALB alarms introduced in v6.1.0 for _ecs/service_.
 
-If the number of hosts in the target group was equal to the minimum healthy
-deployment percentage, the "not enough healthy hosts" alarm would fire -- even
-though this is normal behaviour, e.g. when ECS is changing task definitions.
+We added a new ALB alarm for "not enough healthy hosts".  Previously it would
+fire if the number of healthy hosts was _equal_ to the minimum allowed number
+(minimum healthy percentage * desired count) -- even though this is normal
+behaviour, e.g. when ECS is changing task definitions.
 
 Now the alarm only fires if the number of hosts drops _below_ the minimum
-healthy number.
+allowed number.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+RELEASE_TYPE: patch
+
+This fixes a bug in the ALB alarms introduced in v6.1.0.
+
+If the number of hosts in the target group was equal to the minimum healthy
+deployment percentage, the "not enough healthy hosts" alarm would fire -- even
+though this is normal behaviour, e.g. when ECS is changing task definitions.
+
+Now the alarm only fires if the number of hosts drops _below_ the minimum
+healthy number.

--- a/_scripts/hypothesistooling.py
+++ b/_scripts/hypothesistooling.py
@@ -257,3 +257,28 @@ def update_for_pending_release():
         'commit',
         '-m', 'Bump version to %s and update changelog' % (__version__,)
     )
+
+
+def changed_files(*args):
+    """
+    Returns a set of changed files in a given commit range.
+
+    :param commit_range: Arguments to pass to ``git diff``.
+    """
+    files = set()
+    command = ['git', 'diff', '--name-only'] + list(args)
+    diff_output = subprocess.check_output(command).decode('ascii')
+    for line in diff_output.splitlines():
+        filepath = line.strip()
+        if filepath:
+            files.add(filepath)
+    return files
+
+
+def make(task, dry_run=False):
+    if dry_run:
+        command = ['make', '--dry-run', task]
+    else:
+        command = ['make', task]
+    print('*** Running %r' % command, flush=True)
+    subprocess.check_call(command)

--- a/_scripts/run_travis_format.py
+++ b/_scripts/run_travis_format.py
@@ -7,6 +7,8 @@ In particular, this script will autoformat Terraform, then commit
 and push the results.
 """
 
+from __future__ import print_function
+
 import os
 import subprocess
 

--- a/_scripts/run_travis_format.py
+++ b/_scripts/run_travis_format.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
             '-in', 'deploy_key.enc',
             '-out', 'deploy_key', '-d'
         ])
-        subprocess.check_call(['chmod', '400', 'id_rsa'])
+        subprocess.check_call(['chmod', '400', 'deploy_key'])
 
         # We checkout the branch before we add the commit, so we don't
         # include the merge commit that Travis makes.

--- a/_scripts/run_travis_format.py
+++ b/_scripts/run_travis_format.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 import os
 import subprocess
 
-from tooling import changed_files, git, make
+from hypothesistooling import changed_files, git, make
 
 
 if __name__ == '__main__':

--- a/_scripts/run_travis_format.py
+++ b/_scripts/run_travis_format.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""
+Wrapper script for doing auto-formatting in Travis.
+
+In particular, this script will autoformat Terraform, then commit
+and push the results.
+"""
+
+import os
+import subprocess
+
+from tooling import changed_files, git, make
+
+
+if __name__ == '__main__':
+    make('format')
+
+    # https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+    if os.environ['TRAVIS_PULL_REQUEST'] == 'false':
+        branch = os.environ['TRAVIS_BRANCH']
+    else:
+        branch = os.environ['TRAVIS_PULL_REQUEST_BRANCH']
+
+    if changed_files():
+        print(
+            '*** There were changes from formatting, creating a commit',
+            flush=True)
+
+        git('config', 'user.name', 'Travis CI on behalf of Wellcome')
+        git('config', 'user.email', 'wellcomedigitalplatform@wellcome.ac.uk')
+        git('config', 'core.sshCommand', 'ssh -i id_rsa')
+
+        git(
+            'remote', 'add', 'ssh-origin',
+            'git@github.com:wellcometrust/terraform-modules.git'
+        )
+
+        # Unencrypt the SSH key.
+        subprocess.check_call([
+            'openssl', 'aes-256-cbc',
+            '-K', os.environ['encrypted_83630750896a_key'],
+            '-iv', os.environ['encrypted_83630750896a_iv'],
+            '-in', 'deploy_key.enc',
+            '-out', 'deploy_key', '-d'
+        ])
+        subprocess.check_call(['chmod', '400', 'id_rsa'])
+
+        # We checkout the branch before we add the commit, so we don't
+        # include the merge commit that Travis makes.
+        git('fetch', 'ssh-origin')
+        git('checkout', branch)
+
+        git('add', '--verbose', '--all')
+        git('commit', '-m', 'Apply auto-formatting rules')
+        git('push', 'ssh-origin', 'HEAD:%s' % branch)
+    else:
+        print('*** There were no changes from auto-formatting', flush=True)

--- a/_scripts/run_travis_format.py
+++ b/_scripts/run_travis_format.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
         git('config', 'user.name', 'Travis CI on behalf of Wellcome')
         git('config', 'user.email', 'wellcomedigitalplatform@wellcome.ac.uk')
-        git('config', 'core.sshCommand', 'ssh -i id_rsa')
+        git('config', 'core.sshCommand', 'ssh -i deploy_key')
 
         git(
             'remote', 'add', 'ssh-origin',

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -38,7 +38,7 @@ module "unhealthy_hosts_alarm" {
 }
 
 locals {
-  healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
+  healthy_host_threshold = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
 }
 
 module "healthy_hosts_alarm" {

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -44,7 +44,7 @@ module "unhealthy_hosts_alarm" {
 # alarm --- this is not an uptime-critical service.
 locals {
   healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
-  enable_healthy_host_alarm = "${local.healthy_host_threshold > 0 && var.enable_alb_alarm}"
+  enable_healthy_host_alarm = "${ceil(local.healthy_host_threshold) > 0 && var.enable_alb_alarm}"
 }
 
 module "healthy_hosts_alarm" {

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -42,7 +42,7 @@ module "unhealthy_hosts_alarm" {
 #
 # If this is zero (i.e. it's okay to go down to no running hosts), we don't
 # alarm --- this is not an uptime-critical service.
-local {
+locals {
   healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
   enable_healthy_host_alarm = "${local.healthy_host_threshold > 0 && var.enable_alb_alarm}"
 }

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -37,18 +37,17 @@ module "unhealthy_hosts_alarm" {
   lb_dimension = "${var.loadbalancer_cloudwatch_id}"
 }
 
-# The metric here is: if we have less than the minimum percent of
-# healthy hosts, we should alarm.
-#
-# If this is zero (i.e. it's okay to go down to no running hosts), we don't
-# alarm --- this is not an uptime-critical service.
 locals {
   healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
-  enable_healthy_host_alarm = "${ceil(local.healthy_host_threshold) > 0 && var.enable_alb_alarm}"
 }
 
 module "healthy_hosts_alarm" {
-  enable_alarm = "${local.enable_healthy_host_alarm}"
+  # The rule here is: if we have less than the minimum percent of
+  # healthy hosts, we should alarm.
+  #
+  # If this is zero (i.e. it's okay to go down to no running hosts), we don't
+  # alarm --- this is not an uptime-critical service.
+  enable_alarm = "${ceil(local.healthy_host_threshold) > 0 && var.enable_alb_alarm ? 1 : 0}"
 
   source = "./alb_alarm"
   name   = "${var.service_name}-alb-not-enough-healthy-hosts"

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -37,19 +37,27 @@ module "unhealthy_hosts_alarm" {
   lb_dimension = "${var.loadbalancer_cloudwatch_id}"
 }
 
+# The metric here is: if we have less than the minimum percent of
+# healthy hosts, we should alarm.
+#
+# If this is zero (i.e. it's okay to go down to no running hosts), we don't
+# alarm --- this is not an uptime-critical service.
+local {
+  healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
+  enable_healthy_host_alarm = "${local.healthy_host_comparison > 0 && var.enable_alb_alarm}"
+}
+
 module "healthy_hosts_alarm" {
-  enable_alarm = "${var.enable_alb_alarm}"
+  enable_alarm = "${local.enable_healthy_host_alarm}"
 
   source = "./alb_alarm"
   name   = "${var.service_name}-alb-not-enough-healthy-hosts"
 
-  comparison_operator = "LessThanOrEqualToThreshold"
+  comparison_operator = "LessThanThreshold"
   metric              = "HealthyHostCount"
   topic_arn           = "${var.server_error_alarm_topic_arn}"
 
-  # The metric here is: if we have less than the desired healthy number
-  # of hosts, we should alarm.
-  threshold = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
+  threshold = "${local.healthy_host_threshold}"
 
   # There have been scenarios where HealthyHostCount doesn't report any data
   # (e.g. when an invalid container definition was pushed).  In this case,

--- a/ecs/service/ecs_service/alarms.tf
+++ b/ecs/service/ecs_service/alarms.tf
@@ -44,7 +44,7 @@ module "unhealthy_hosts_alarm" {
 # alarm --- this is not an uptime-critical service.
 local {
   healthy_host_threshold    = "${var.deployment_minimum_healthy_percent * var.desired_count / 100.0}"
-  enable_healthy_host_alarm = "${local.healthy_host_comparison > 0 && var.enable_alb_alarm}"
+  enable_healthy_host_alarm = "${local.healthy_host_threshold > 0 && var.enable_alb_alarm}"
 }
 
 module "healthy_hosts_alarm" {


### PR DESCRIPTION
Specifically, don't fire when you're scaling a deployment!