### PR TITLE
Add custom security groups to instances in ASG

### DIFF
--- a/ecs/cluster/asg/ecs_asg_launch_config/main.tf
+++ b/ecs/cluster/asg/ecs_asg_launch_config/main.tf
@@ -1,9 +1,7 @@
 resource "aws_launch_configuration" "ondemand_launch_config" {
   count = "${var.use_spot == true ? 0 : "${var.ebs_device_name == "" ? 1 : 0}" }"
 
-  security_groups = [
-    "${aws_security_group.instance_sg.id}",
-  ]
+  security_groups = ["${aws_security_group.instance_sg.id}", "${var.instance_security_groups}"]
 
   key_name                    = "${var.key_name}"
   image_id                    = "${var.image_id}"

--- a/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
+++ b/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
@@ -38,6 +38,12 @@ variable "random_key" {
   default = "initial"
 }
 
+variable "instance_security_groups" {
+  description = "Security groups to add to the launch config for the ASG"
+  type        = "list"
+  default     = []
+}
+
 variable "use_spot" {}
 variable spot_price {}
 

--- a/ecs/cluster/asg/main.tf
+++ b/ecs/cluster/asg/main.tf
@@ -31,6 +31,8 @@ module "launch_config" {
   public_ip             = "${var.public_ip}"
   ebs_volume_type       = "${var.ebs_volume_type}"
   ebs_iops              = "${var.ebs_iops}"
+
+  instance_security_groups = "${var.instance_security_groups}"
 }
 
 module "instance_profile" {

--- a/ecs/cluster/asg/variables.tf
+++ b/ecs/cluster/asg/variables.tf
@@ -87,3 +87,9 @@ variable "ebs_volume_type" {
 variable "ebs_iops" {
   default = ""
 }
+
+variable "instance_security_groups" {
+  description = "Security groups to add to the launch config for the ASG"
+  type        = "list"
+  default     = []
+}

--- a/ecs/cluster/asg_ondemand.tf
+++ b/ecs/cluster/asg_ondemand.tf
@@ -37,4 +37,6 @@ module "cluster_asg_on_demand" {
   publish_to_sns_policy = "${var.ec2_terminating_topic_publish_policy}"
 
   alarm_topic_arn = "${var.ec2_instance_terminating_for_too_long_alarm_arn}"
+
+  instance_security_groups = "${var.instance_security_groups}"
 }

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -60,3 +60,9 @@ variable "alb_log_bucket_id" {}
 variable "ec2_terminating_topic_arn" {}
 variable "ec2_terminating_topic_publish_policy" {}
 variable "ec2_instance_terminating_for_too_long_alarm_arn" {}
+
+variable "instance_security_groups" {
+  description = "Security groups to add to the launch config for the ASG"
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
Allows adding your own security groups to ASG launch config for instances.

This PR also allows you to do this at the abstraction level of ECS cluster.