### PR TITLE
Allow admin_cidr_ingress to be a list of CIDR blocks

### DIFF
--- a/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
+++ b/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
@@ -31,7 +31,7 @@ variable "public_ip" {
 }
 
 variable "admin_cidr_ingress" {
-  type = "list"
+  type        = "list"
   description = "CIDR for SSH access to EC2 instances"
 }
 

--- a/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
+++ b/ecs/cluster/asg/ecs_asg_launch_config/variables.tf
@@ -31,6 +31,7 @@ variable "public_ip" {
 }
 
 variable "admin_cidr_ingress" {
+  type = "list"
   description = "CIDR for SSH access to EC2 instances"
 }
 

--- a/ecs/cluster/asg/variables.tf
+++ b/ecs/cluster/asg/variables.tf
@@ -44,7 +44,8 @@ variable "vpc_id" {
 }
 
 variable "admin_cidr_ingress" {
-  default     = "0.0.0.0/0"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
   description = "CIDR for SSH access to EC2 instances"
 }
 

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -7,7 +7,8 @@ variable "key_name" {
 }
 
 variable "admin_cidr_ingress" {
-  default     = "0.0.0.0/0"
+  type        = "list"
+  default     = ["0.0.0.0/0"]
   description = "CIDR for SSH access to EC2 instances"
 }
 


### PR DESCRIPTION
In order that multiple different subnets can SSH to instances.