### PR TITLE
add variable efs_filesystem_id to pass it on to userdata module

### DIFF
--- a/ecs/cluster/userdata.tf
+++ b/ecs/cluster/userdata.tf
@@ -1,4 +1,5 @@
 module "cluster_userdata" {
-  source       = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
-  cluster_name = "${aws_ecs_cluster.cluster.name}"
+  source            = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
+  cluster_name      = "${aws_ecs_cluster.cluster.name}"
+  efs_filesystem_id = "${var.efs_filesystem_id}"
 }

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -60,3 +60,7 @@ variable "alb_log_bucket_id" {}
 variable "ec2_terminating_topic_arn" {}
 variable "ec2_terminating_topic_publish_policy" {}
 variable "ec2_instance_terminating_for_too_long_alarm_arn" {}
+
+variable "efs_filesystem_id" {
+  default = "no_name_set"
+}


### PR DESCRIPTION
To allow for an ECS cluster with an EFS mounted, the variable efs_filesystem_id is introduced in the ecs/cluster module and passed on to the userdata module (default value is the same in both modules).