### PR TITLE
EFS: allow access to EFS mount targets from list of security groups

### DIFF
--- a/efs/README.md
+++ b/efs/README.md
@@ -5,7 +5,7 @@ AWS Elastic File System module.
 This module creates:
 - An EFS filesystem
 - Mount points for each subnet specified
-- Permissions to access the filesystem for the specified security group
+- Permissions to access the filesystem for the specified security groups
 
 
 ## Usage
@@ -18,8 +18,8 @@ module "my_efs_module" {
   vpc_id  = "${var.vpc_id}"
   subnets = ["${var.my_subnets}"]
 
-  # Security group ID for ingress
-  efs_access_security_group_id = "${var.security_group_id}"
+  # Security group IDs for ingress
+  efs_access_security_group_ids = [${var.security_group_ids}"]
 }
 ```
 

--- a/efs/main.tf
+++ b/efs/main.tf
@@ -20,8 +20,6 @@ resource "aws_security_group" "efs_mnt" {
     from_port = 2049
     to_port   = 2049
 
-    security_groups = [
-      "${var.efs_access_security_group_id}",
-    ]
+    security_groups = ["${var.efs_access_security_group_ids}"]
   }
 }

--- a/efs/variables.tf
+++ b/efs/variables.tf
@@ -11,8 +11,9 @@ variable "vpc_id" {
   description = "ID of VPC to to create EFS mount in"
 }
 
-variable "efs_access_security_group_id" {
-  description = "ID of the security group of the EC2 instaces that need to access the EFS"
+variable "efs_access_security_group_ids" {
+  type        = "list"
+  description = "IDs of the security groups of the EC2 instances that need to access the EFS"
 }
 
 variable "performance_mode" {


### PR DESCRIPTION
Changing variable to allow a list of security groups to be used in the
ingress rules for the EFS mount targets.

This can then be used by the ECS/cluster module with its on demand and spot instances SGs.