### PR TITLE
Ignore missing data to avoid autoscaling being triggered up and down

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release fixes a suspected bug in SQS autoscaling where both scale down and scale up alarms where triggered at the same time.

--- a/autoscaling/alarms/sqs/main.tf
+++ b/autoscaling/alarms/sqs/main.tf
@@ -22,7 +22,7 @@ module "queue_low" {
   threshold = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"
-  treat_missing_data  = "breaching"
+  treat_missing_data  = "ignore"
 
   target_arn = "${var.scale_down_arn}"
 }


### PR DESCRIPTION
I've seen weird behaviour in the sqs autoscaling where both the scale down and scale up alarms are triggered and that makes the autoscaling go up and down. _I think_ this is due to the fact that we that missing data as breaching for the scale down alarm which makes it possible for both alarms to be triggered at the same time. 
I've set it to ignore for the elasticdump and it seems to be behaving better

![amazon ecs](https://user-images.githubusercontent.com/26736746/38939783-9e0e6208-4320-11e8-8d7e-dd49365336bb.png)
