### PR TITLE
Autoscaling bugfixes and tweaks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Make scaling up and down evaluation periods configurable.
+Ignore missing data for scaling up alarms to avoid scaling up too often.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
 RELEASE_TYPE: minor
 
-Make scaling up and down evaluation periods configurable.
-Ignore missing data for scaling up alarms to avoid scaling up too often.
+* Make scale up and down period for an sqs_autoscaling_service be configurable
+* Fix a bug in the way the cloudwatch metrics alarm are defined which caused them to scale down (or up) before the scaledown period had passed
+* Make the ecs cluster use the submodules from the same release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 Make scaling up and down evaluation periods configurable.
 Ignore missing data for scaling up alarms to avoid scaling up too often.

--- a/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
+++ b/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
@@ -1,7 +1,8 @@
 resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   alarm_name          = "${var.name}-ecs_cpureservation_${var.comparison_operator}"
   comparison_operator = "${var.comparison_operator}"
-  evaluation_periods  = "1"
+  evaluation_periods  = "${var.period / 60}"
+  datapoints_to_alarm = "${var.period / 60}"
   metric_name         = "CPUReservation"
 
   dimensions {
@@ -11,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   statistic = "Average"
   namespace = "AWS/ECS"
 
-  period    = "${var.period}"
+  period    = "60}"
   threshold = "${var.threshold}"
 
   treat_missing_data = "${var.treat_missing_data}"

--- a/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
+++ b/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
@@ -1,8 +1,15 @@
 resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   alarm_name          = "${var.name}-ecs_cpureservation_${var.comparison_operator}"
   comparison_operator = "${var.comparison_operator}"
-  evaluation_periods  = "${var.period / 60}"
-  datapoints_to_alarm = "${var.period / 60}"
+
+  // Actual period during which the threshold is evaluated
+  // It depends on the size of the periods over which statistics
+  // datapoints are generated.
+  // Our datapoints are hardcoded to represent statistics
+  // over one minute (see below), so the evaluation period
+  // is defined in minutes
+  evaluation_periods  = "${var.period_in_minutes}"
+  datapoints_to_alarm = "${var.period_in_minutes}"
   metric_name         = "CPUReservation"
 
   dimensions {
@@ -12,6 +19,9 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   statistic = "Average"
   namespace = "AWS/ECS"
 
+  // This is the period over which the statistic is calculated
+  // An evaluation over this period produces one datapoint
+  // This is NOT the period during which the threshold is evaluated
   period    = "60"
   threshold = "${var.threshold}"
 

--- a/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
+++ b/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   statistic = "Average"
   namespace = "AWS/ECS"
 
-  period    = "60}"
+  period    = "60"
   threshold = "${var.threshold}"
 
   treat_missing_data = "${var.treat_missing_data}"

--- a/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
+++ b/autoscaling/alarms/cpureservation/cpureservation_alarm/main.tf
@@ -8,7 +8,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   // Our datapoints are hardcoded to represent statistics
   // over one minute (see below), so the evaluation period
   // is defined in minutes
-  evaluation_periods  = "${var.period_in_minutes}"
+  evaluation_periods = "${var.period_in_minutes}"
+
   datapoints_to_alarm = "${var.period_in_minutes}"
   metric_name         = "CPUReservation"
 
@@ -22,7 +23,8 @@ resource "aws_cloudwatch_metric_alarm" "ecs_cpureservation_high" {
   // This is the period over which the statistic is calculated
   // An evaluation over this period produces one datapoint
   // This is NOT the period during which the threshold is evaluated
-  period    = "60"
+  period = "60"
+
   threshold = "${var.threshold}"
 
   treat_missing_data = "${var.treat_missing_data}"

--- a/autoscaling/alarms/cpureservation/cpureservation_alarm/variables.tf
+++ b/autoscaling/alarms/cpureservation/cpureservation_alarm/variables.tf
@@ -1,7 +1,7 @@
 variable "name" {}
 variable "comparison_operator" {}
 variable "cluster_name" {}
-variable "period" {}
+variable "period_in_minutes" {}
 variable "threshold" {}
 
 variable "treat_missing_data" {

--- a/autoscaling/alarms/cpureservation/main.tf
+++ b/autoscaling/alarms/cpureservation/main.tf
@@ -4,8 +4,8 @@ module "cpureservation_high" {
 
   cluster_name = "${var.cluster_name}"
 
-  period_in_minutes    = "${var.high_period_in_minutes}"
-  threshold = "${var.high_threshold}"
+  period_in_minutes = "${var.high_period_in_minutes}"
+  threshold         = "${var.high_threshold}"
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   treat_missing_data  = "${var.treat_missing_data_high}"
@@ -19,8 +19,8 @@ module "cpureservation_low" {
 
   cluster_name = "${var.cluster_name}"
 
-  period_in_minutes    = "${var.low_period_in_minutes}"
-  threshold = "${var.low_threshold}"
+  period_in_minutes = "${var.low_period_in_minutes}"
+  threshold         = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"
   treat_missing_data  = "${var.treat_missing_data_low}"

--- a/autoscaling/alarms/cpureservation/main.tf
+++ b/autoscaling/alarms/cpureservation/main.tf
@@ -4,7 +4,7 @@ module "cpureservation_high" {
 
   cluster_name = "${var.cluster_name}"
 
-  period    = "${var.high_period}"
+  period_in_minutes    = "${var.high_period_in_minutes}"
   threshold = "${var.high_threshold}"
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -19,7 +19,7 @@ module "cpureservation_low" {
 
   cluster_name = "${var.cluster_name}"
 
-  period    = "${var.low_period}"
+  period_in_minutes    = "${var.low_period_in_minutes}"
   threshold = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"

--- a/autoscaling/alarms/cpureservation/variables.tf
+++ b/autoscaling/alarms/cpureservation/variables.tf
@@ -21,17 +21,13 @@ variable "scale_down_adjustment" {
   default = -1
 }
 
-variable "high_period" {
-  default = "60"
-}
+variable "high_period_in_minutes" {}
 
 variable "high_threshold" {
   default = "80"
 }
 
-variable "low_period" {
-  default = "300"
-}
+variable "low_period_in_minutes" {}
 
 variable "low_threshold" {
   default = "80"

--- a/autoscaling/alarms/sqs/main.tf
+++ b/autoscaling/alarms/sqs/main.tf
@@ -22,7 +22,6 @@ module "queue_low" {
   threshold = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"
-  treat_missing_data  = "ignore"
 
   target_arn = "${var.scale_down_arn}"
 }

--- a/autoscaling/alarms/sqs/main.tf
+++ b/autoscaling/alarms/sqs/main.tf
@@ -4,8 +4,8 @@ module "queue_high" {
 
   queue_name = "${var.queue_name}"
 
-  period_in_minutes    = "${var.high_period_in_minutes}"
-  threshold = "${var.high_threshold}"
+  period_in_minutes = "${var.high_period_in_minutes}"
+  threshold         = "${var.high_threshold}"
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
@@ -18,8 +18,8 @@ module "queue_low" {
 
   queue_name = "${var.queue_name}"
 
-  period_in_minutes    = "${var.low_period_in_minutes}"
-  threshold = "${var.low_threshold}"
+  period_in_minutes = "${var.low_period_in_minutes}"
+  threshold         = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"
 

--- a/autoscaling/alarms/sqs/main.tf
+++ b/autoscaling/alarms/sqs/main.tf
@@ -4,7 +4,7 @@ module "queue_high" {
 
   queue_name = "${var.queue_name}"
 
-  period    = "${var.high_period}"
+  period_in_minutes    = "${var.high_period_in_minutes}"
   threshold = "${var.high_threshold}"
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -18,7 +18,7 @@ module "queue_low" {
 
   queue_name = "${var.queue_name}"
 
-  period    = "${var.low_period}"
+  period_in_minutes    = "${var.low_period_in_minutes}"
   threshold = "${var.low_threshold}"
 
   comparison_operator = "LessThanThreshold"

--- a/autoscaling/alarms/sqs/sqs_alarm/main.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/main.tf
@@ -1,7 +1,8 @@
 resource "aws_cloudwatch_metric_alarm" "queue" {
   alarm_name          = "${var.name}-queue_${var.comparison_operator}"
   comparison_operator = "${var.comparison_operator}"
-  evaluation_periods  = "1"
+  evaluation_periods  = "${var.period / 60}"
+  datapoints_to_alarm = "${var.period / 60}"
   metric_name         = "ApproximateNumberOfMessagesVisible"
 
   dimensions {
@@ -11,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "queue" {
   statistic = "Average"
   namespace = "AWS/SQS"
 
-  period    = "${var.period}"
+  period    = "60"
   threshold = "${var.threshold}"
 
   treat_missing_data = "${var.treat_missing_data}"

--- a/autoscaling/alarms/sqs/sqs_alarm/main.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/main.tf
@@ -1,8 +1,15 @@
 resource "aws_cloudwatch_metric_alarm" "queue" {
   alarm_name          = "${var.name}-queue_${var.comparison_operator}"
   comparison_operator = "${var.comparison_operator}"
-  evaluation_periods  = "${var.period / 60}"
-  datapoints_to_alarm = "${var.period / 60}"
+
+  // Actual period during which the threshold is evaluated
+  // It depends on the size of the periods over which statistics
+  // datapoints are generated.
+  // Our datapoints are hardcoded to represent statistics
+  // over one minute (see below), so the evaluation period
+  // is defined in minutes
+  evaluation_periods  = "${var.period_in_minutes}"
+  datapoints_to_alarm = "${var.period_in_minutes}"
   metric_name         = "ApproximateNumberOfMessagesVisible"
 
   dimensions {
@@ -12,6 +19,9 @@ resource "aws_cloudwatch_metric_alarm" "queue" {
   statistic = "Average"
   namespace = "AWS/SQS"
 
+  // This is the period over which the statistic is calculated
+  // An evaluation over this period produces one datapoint
+  // This is NOT the period during which the threshold is evaluated
   period    = "60"
   threshold = "${var.threshold}"
 

--- a/autoscaling/alarms/sqs/sqs_alarm/main.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/main.tf
@@ -8,7 +8,8 @@ resource "aws_cloudwatch_metric_alarm" "queue" {
   // Our datapoints are hardcoded to represent statistics
   // over one minute (see below), so the evaluation period
   // is defined in minutes
-  evaluation_periods  = "${var.period_in_minutes}"
+  evaluation_periods = "${var.period_in_minutes}"
+
   datapoints_to_alarm = "${var.period_in_minutes}"
   metric_name         = "ApproximateNumberOfMessagesVisible"
 
@@ -22,7 +23,8 @@ resource "aws_cloudwatch_metric_alarm" "queue" {
   // This is the period over which the statistic is calculated
   // An evaluation over this period produces one datapoint
   // This is NOT the period during which the threshold is evaluated
-  period    = "60"
+  period = "60"
+
   threshold = "${var.threshold}"
 
   treat_missing_data = "${var.treat_missing_data}"

--- a/autoscaling/alarms/sqs/sqs_alarm/variables.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/variables.tf
@@ -6,5 +6,5 @@ variable "threshold" {}
 variable "target_arn" {}
 
 variable "treat_missing_data" {
-  default = "ignore"
+  default = "missing"
 }

--- a/autoscaling/alarms/sqs/sqs_alarm/variables.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/variables.tf
@@ -6,5 +6,5 @@ variable "threshold" {}
 variable "target_arn" {}
 
 variable "treat_missing_data" {
-  default = "missing"
+  default = "ignore"
 }

--- a/autoscaling/alarms/sqs/sqs_alarm/variables.tf
+++ b/autoscaling/alarms/sqs/sqs_alarm/variables.tf
@@ -1,7 +1,7 @@
 variable "name" {}
 variable "comparison_operator" {}
 variable "queue_name" {}
-variable "period" {}
+variable "period_in_minutes" {}
 variable "threshold" {}
 variable "target_arn" {}
 

--- a/autoscaling/alarms/sqs/variables.tf
+++ b/autoscaling/alarms/sqs/variables.tf
@@ -20,17 +20,13 @@ variable "max_capacity" {
   default = 3
 }
 
-variable "high_period" {
-  default = 60
-}
+variable "high_period" {}
 
 variable "high_threshold" {
   default = 1
 }
 
-variable "low_period" {
-  default = 600
-}
+variable "low_period" {}
 
 variable "low_threshold" {
   default = 1

--- a/autoscaling/alarms/sqs/variables.tf
+++ b/autoscaling/alarms/sqs/variables.tf
@@ -20,13 +20,13 @@ variable "max_capacity" {
   default = 3
 }
 
-variable "high_period" {}
+variable "high_period_in_minutes" {}
 
 variable "high_threshold" {
   default = 1
 }
 
-variable "low_period" {}
+variable "low_period_in_minutes" {}
 
 variable "low_threshold" {
   default = 1

--- a/ecs/cluster/asg_ondemand.tf
+++ b/ecs/cluster/asg_ondemand.tf
@@ -1,12 +1,12 @@
 module "cluster_asg_on_demand_autoscaling" {
-  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/asg?ref=v1.1.0"
+  source = "../../autoscaling/asg"
   name   = "${var.name}_on_demand"
 
   scalegroup_name = "${module.cluster_asg_on_demand.asg_name}"
 }
 
 module "cluster_asg_on_demand_asg_totalinstances_autoscaling_alarms" {
-  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/alarms/asg_totalinstances?ref=v1.1.0"
+  source = "../../autoscaling/alarms/asg_totalinstances"
   name   = "${var.name}_on_demand"
 
   asg_name = "${module.cluster_asg_spot.asg_name}"

--- a/ecs/cluster/asg_spot.tf
+++ b/ecs/cluster/asg_spot.tf
@@ -11,10 +11,10 @@ module "cluster_asg_spot_cpureservation_autoscaling_alarms" {
 
   cluster_name = "${aws_ecs_cluster.cluster.name}"
 
-  scale_up_arn   = "${module.cluster_asg_spot_autoscaling.scale_up_arn}"
-  scale_down_arn = "${module.cluster_asg_spot_autoscaling.scale_down_arn}"
+  scale_up_arn           = "${module.cluster_asg_spot_autoscaling.scale_up_arn}"
+  scale_down_arn         = "${module.cluster_asg_spot_autoscaling.scale_down_arn}"
   high_period_in_minutes = "${var.scale_up_period_in_minutes}"
-  low_period_in_minutes = "${var.scale_down_period_in_minutes}"
+  low_period_in_minutes  = "${var.scale_down_period_in_minutes}"
 }
 
 module "cluster_asg_spot" {

--- a/ecs/cluster/asg_spot.tf
+++ b/ecs/cluster/asg_spot.tf
@@ -13,6 +13,8 @@ module "cluster_asg_spot_cpureservation_autoscaling_alarms" {
 
   scale_up_arn   = "${module.cluster_asg_spot_autoscaling.scale_up_arn}"
   scale_down_arn = "${module.cluster_asg_spot_autoscaling.scale_down_arn}"
+  high_period_in_minutes = "${var.scale_up_period_in_minutes}"
+  low_period_in_minutes = "${var.scale_down_period_in_minutes}"
 }
 
 module "cluster_asg_spot" {

--- a/ecs/cluster/asg_spot.tf
+++ b/ecs/cluster/asg_spot.tf
@@ -1,12 +1,12 @@
 module "cluster_asg_spot_autoscaling" {
-  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/asg?ref=v1.1.0"
+  source = "../../autoscaling/asg"
   name   = "${var.name}_spot"
 
   scalegroup_name = "${module.cluster_asg_spot.asg_name}"
 }
 
 module "cluster_asg_spot_cpureservation_autoscaling_alarms" {
-  source = "git::https://github.com/wellcometrust/terraform.git//autoscaling/alarms/cpureservation?ref=v1.1.0"
+  source = "../../autoscaling/alarms/cpureservation"
   name   = "${var.name}_spot"
 
   cluster_name = "${aws_ecs_cluster.cluster.name}"

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -65,3 +65,10 @@ variable "ec2_instance_terminating_for_too_long_alarm_arn" {}
 variable "efs_filesystem_id" {
   default = "no_name_set"
 }
+
+variable "scale_up_period_in_minutes" {
+  default = 1
+}
+variable "scale_down_period_in_minutes" {
+  default = 5
+}

--- a/ecs/cluster/variables.tf
+++ b/ecs/cluster/variables.tf
@@ -69,6 +69,7 @@ variable "efs_filesystem_id" {
 variable "scale_up_period_in_minutes" {
   default = 1
 }
+
 variable "scale_down_period_in_minutes" {
   default = 5
 }

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -17,6 +17,9 @@ module "sqs_autoscaling_alarms" {
 
   scale_up_arn   = "${module.appautoscaling.scale_up_arn}"
   scale_down_arn = "${module.appautoscaling.scale_down_arn}"
+
+  high_period = "${var.scale_up_period}"
+  low_period = "${var.scale_down_period}"
 }
 
 data "aws_ecs_cluster" "cluster" {

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -19,7 +19,7 @@ module "sqs_autoscaling_alarms" {
   scale_down_arn = "${module.appautoscaling.scale_down_arn}"
 
   high_period = "${var.scale_up_period}"
-  low_period = "${var.scale_down_period}"
+  low_period  = "${var.scale_down_period}"
 }
 
 data "aws_ecs_cluster" "cluster" {

--- a/sqs_autoscaling_service/main.tf
+++ b/sqs_autoscaling_service/main.tf
@@ -18,8 +18,8 @@ module "sqs_autoscaling_alarms" {
   scale_up_arn   = "${module.appautoscaling.scale_up_arn}"
   scale_down_arn = "${module.appautoscaling.scale_down_arn}"
 
-  high_period = "${var.scale_up_period}"
-  low_period  = "${var.scale_down_period}"
+  high_period_in_minutes = "${var.scale_up_period_in_minutes}"
+  low_period_in_minutes  = "${var.scale_down_period_in_minutes}"
 }
 
 data "aws_ecs_cluster" "cluster" {

--- a/sqs_autoscaling_service/variables.tf
+++ b/sqs_autoscaling_service/variables.tf
@@ -44,10 +44,10 @@ variable "max_capacity" {
   default = 3
 }
 
-variable "scale_up_period" {
-  default = 60
+variable "scale_up_period_in_minutes" {
+  default = 1
 }
 
-variable "scale_down_period" {
-  default = 600
+variable "scale_down_period_in_minutes" {
+  default = 10
 }

--- a/sqs_autoscaling_service/variables.tf
+++ b/sqs_autoscaling_service/variables.tf
@@ -43,3 +43,11 @@ variable "min_capacity" {
 variable "max_capacity" {
   default = 3
 }
+
+variable "scale_up_period" {
+  default = 60
+}
+
+variable "scale_down_period" {
+  default = 600
+}


### PR DESCRIPTION
* Make scale up and down period for an `sqs_autoscaling_service` be configurable
* Fix a bug in the way the cloudwatch metrics alarm are defined which caused them to scale down (or up) before the scaledown period had passed
* Refernce directly the autoscaling modules in the ecs cluster instead of using git ref so that the code from a certain release can be used throughout