### PR TITLE
Add Fargate launch type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This change adds the ability to set the ECS Service launch type to FARGATE

--- a/ecs/service/ecs_service/ecs.tf
+++ b/ecs/service/ecs_service/ecs.tf
@@ -14,6 +14,8 @@ resource "aws_ecs_service" "service" {
     container_port   = "${var.container_port}"
   }
 
+  launch_type = "${var.launch_type}"
+
   lifecycle {
     # Unfortunately, when changing a service, this prevents the creation of the
     # service with the error:

--- a/ecs/service/ecs_service/variables.tf
+++ b/ecs/service/ecs_service/variables.tf
@@ -55,18 +55,26 @@ variable "host_name" {
 
 variable "server_error_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for 5xx ALB state"
+  default = ""
 }
 
 variable "client_error_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for 4xx ALB state"
+  default = ""
 }
 
 variable "loadbalancer_cloudwatch_id" {
   description = "LoadBalancer ARN Suffix"
+  default = ""
 }
 
 variable "enable_alb_alarm" {
   default = 1
+}
+
+variable "launch_type" {
+  default = "EC2"
+  description = "Cluster launch type, can be 'EC2' or 'FARGATE', defaults to EC2"
 }
 
 variable "deployment_minimum_healthy_percent" {}

--- a/ecs/service/ecs_service/variables.tf
+++ b/ecs/service/ecs_service/variables.tf
@@ -55,17 +55,17 @@ variable "host_name" {
 
 variable "server_error_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for 5xx ALB state"
-  default = ""
+  default     = ""
 }
 
 variable "client_error_alarm_topic_arn" {
   description = "ARN of the topic where to send notification for 4xx ALB state"
-  default = ""
+  default     = ""
 }
 
 variable "loadbalancer_cloudwatch_id" {
   description = "LoadBalancer ARN Suffix"
-  default = ""
+  default     = ""
 }
 
 variable "enable_alb_alarm" {
@@ -73,7 +73,7 @@ variable "enable_alb_alarm" {
 }
 
 variable "launch_type" {
-  default = "EC2"
+  default     = "EC2"
   description = "Cluster launch type, can be 'EC2' or 'FARGATE', defaults to EC2"
 }
 

--- a/ecs/service/main.tf
+++ b/ecs/service/main.tf
@@ -27,6 +27,7 @@ module "service" {
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 
+  launch_type = "${var.launch_type}"
   enable_alb_alarm = "${var.enable_alb_alarm}"
 }
 

--- a/ecs/service/main.tf
+++ b/ecs/service/main.tf
@@ -27,7 +27,7 @@ module "service" {
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 
-  launch_type = "${var.launch_type}"
+  launch_type      = "${var.launch_type}"
   enable_alb_alarm = "${var.enable_alb_alarm}"
 }
 

--- a/ecs/service/variables.tf
+++ b/ecs/service/variables.tf
@@ -145,6 +145,6 @@ variable "task_definition_template_path" {
 }
 
 variable "launch_type" {
-  default = "EC2"
+  default     = "EC2"
   description = "Cluster launch type, can be 'EC2' or 'FARGATE', defaults to EC2"
 }

--- a/ecs/service/variables.tf
+++ b/ecs/service/variables.tf
@@ -143,3 +143,8 @@ variable "task_definition_template_path" {
   description = "A custom task definition template to use"
   default     = ""
 }
+
+variable "launch_type" {
+  default = "EC2"
+  description = "Cluster launch type, can be 'EC2' or 'FARGATE', defaults to EC2"
+}


### PR DESCRIPTION
Adds the ability to run compute from AWS Fargate for an ECS service.