### PR TITLE
Add container uri as APP_NAME env var in ecs service module

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This change adds an `APP_NAME` environment variable to the task definition of tasks created with the `ecs` module. The `APP_NAME` variable is set to the value of the container uri used as the primary container in the service.

--- a/ecs/service/main.tf
+++ b/ecs/service/main.tf
@@ -54,6 +54,7 @@ module "task" {
     HTTPS_DOMAIN = "${var.https_domain}"
     APP_PORT     = "${var.secondary_container_port}"
     NGINX_PORT   = "${var.primary_container_port}"
+    APP_NAME     = "${var.app_uri}"
   }
 
   config_vars        = "${var.env_vars}"


### PR DESCRIPTION
This change adds an `APP_NAME` environment variable to the task definition of tasks created with the `ecs` module. The `APP_NAME` variable is set to the value of the container uri used as the primary container in the service.