### PR TITLE
Deprecate the config_var_length variable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: minor
+
+This release deprecates the following variables:
+
+*   `config_vars_length` in `ecs/service/ecs_task`
+*   `env_vars_length` in `ecs/service`
+*   `env_vars_length` in `sqs_autoscaling_service`
+
+Their existence was always a nasty hack around some Terraform interpolation
+issues, and it looks like we can get rid of them.  They can be safely removed
+with no effect.

--- a/ecs/service/ecs_task/data.tf
+++ b/ecs/service/ecs_task/data.tf
@@ -97,7 +97,7 @@ data "aws_iam_role" "task_role" {
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
-  count    = "${var.config_vars_length + length(var.service_vars)}"
+  count    = "${length(var.config_vars) + length(var.service_vars)}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/ecs/service/ecs_task/variables.tf
+++ b/ecs/service/ecs_task/variables.tf
@@ -61,7 +61,10 @@ variable "config_vars" {
   type        = "map"
 }
 
-variable "config_vars_length" {}
+variable "config_vars_length" {
+  description = "[Deprecated] Length of the config_vars map"
+  default     = 0
+}
 
 variable "memory" {
   description = "How much memory to allocate to the app"

--- a/ecs/service/variables.tf
+++ b/ecs/service/variables.tf
@@ -88,7 +88,10 @@ variable "env_vars" {
   default     = {}
 }
 
-variable "env_vars_length" {}
+variable "env_vars_length" {
+  description = "[Deprecated] Length of the env_vars map"
+  default     = 0
+}
 
 variable "host_name" {
   description = "Hostname to be matched in the host condition"

--- a/sqs_autoscaling_service/variables.tf
+++ b/sqs_autoscaling_service/variables.tf
@@ -19,7 +19,10 @@ variable "env_vars" {
   type        = "map"
 }
 
-variable "env_vars_length" {}
+variable "env_vars_length" {
+  description = "[Deprecated] Length of the env_vars map"
+  default     = 0
+}
 
 variable "alb_priority" {
   description = "ALB listener rule priority.  If blank, a priority will be randomly assigned."


### PR DESCRIPTION
Its existence was always a terrible hack, and some testing in the reindexer suggests we're now using a new enough version of Terraform not to need it. (Fingers crossed!)