### PR TITLE
Use name_prefix rather than generating our own suffixes

### DIFF
--- a/ec2/asg/launch_config/security_groups.tf
+++ b/ec2/asg/launch_config/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "ssh_controlled_ingress" {
   description = "controls direct access to application instances"
   vpc_id      = "${var.vpc_id}"
-  name        = "${var.asg_name}_ssh_controlled_ingress_${random_id.sg_append.hex}"
+  name_prefix = "${var.asg_name}_ssh_controlled_ingress"
 
   ingress {
     protocol  = "tcp"
@@ -21,7 +21,7 @@ resource "aws_security_group" "ssh_controlled_ingress" {
 resource "aws_security_group" "full_egress" {
   description = "controls direct access to application instances"
   vpc_id      = "${var.vpc_id}"
-  name        = "${var.asg_name}_full_egress_${random_id.sg_append.hex}"
+  name_prefix = "${var.asg_name}_full_egress"
 
   egress {
     from_port   = 0
@@ -33,12 +33,4 @@ resource "aws_security_group" "full_egress" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "random_id" "sg_append" {
-  keepers = {
-    sg_id = "${var.asg_name}"
-  }
-
-  byte_length = 8
 }

--- a/ecs/cluster/asg/ecs_asg_launch_config/security_groups.tf
+++ b/ecs/cluster/asg/ecs_asg_launch_config/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "instance_sg" {
   description = "controls direct access to application instances"
   vpc_id      = "${var.vpc_id}"
-  name        = "${var.asg_name}_instance_sg_${random_id.sg_append.hex}"
+  name_prefix = "${var.asg_name}_instance_sg"
 
   ingress {
     protocol  = "tcp"
@@ -38,8 +38,8 @@ resource "aws_security_group" "instance_sg" {
 resource "aws_security_group" "http" {
   description = "Allow HTTP access to the ELB"
 
-  vpc_id = "${var.vpc_id}"
-  name   = "${var.asg_name}_loadbalancer_sg_http_${random_id.sg_append.hex}"
+  vpc_id      = "${var.vpc_id}"
+  name_prefix = "${var.asg_name}_loadbalancer_sg_http"
 
   ingress {
     protocol  = "tcp"
@@ -69,8 +69,8 @@ resource "aws_security_group" "http" {
 resource "aws_security_group" "https" {
   description = "Allow HTTPS access to the ELB"
 
-  vpc_id = "${var.vpc_id}"
-  name   = "${var.asg_name}_loadbalancer_sg_https_${random_id.sg_append.hex}"
+  vpc_id      = "${var.vpc_id}"
+  name_prefix = "${var.asg_name}_loadbalancer_sg_https"
 
   ingress {
     protocol  = "tcp"
@@ -95,12 +95,4 @@ resource "aws_security_group" "https" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "random_id" "sg_append" {
-  keepers = {
-    sg_id = "${var.random_key}"
-  }
-
-  byte_length = 8
 }

--- a/lambda/trigger_cloudwatch/cloudwatch.tf
+++ b/lambda/trigger_cloudwatch/cloudwatch.tf
@@ -1,12 +1,6 @@
 /* Configures a Cloudwatch trigger for a Lambda */
 
-resource "random_id" "cloudwatch_trigger_name" {
-  byte_length = 8
-  prefix      = "AllowExecutionFromCloudWatch_${var.lambda_function_name}_"
-}
-
 resource "aws_lambda_permission" "allow_cloudwatch_trigger" {
-  statement_id  = "${random_id.cloudwatch_trigger_name.id}"
   action        = "lambda:InvokeFunction"
   function_name = "${var.lambda_function_name}"
   principal     = "events.amazonaws.com"

--- a/lambda/trigger_sns/sns.tf
+++ b/lambda/trigger_sns/sns.tf
@@ -1,15 +1,4 @@
-/* Configures an SNS trigger for a Lambda */
-resource "random_id" "statement_id" {
-  keepers = {
-    # Generate a new id each time we switch to a new topic subscription
-    aws_sns_topic_subscription = "${aws_sns_topic_subscription.topic_lambda.id}"
-  }
-
-  byte_length = 8
-}
-
 resource "aws_lambda_permission" "allow_sns_trigger" {
-  statement_id  = "${random_id.statement_id.hex}"
   action        = "lambda:InvokeFunction"
   function_name = "${var.lambda_function_arn}"
   principal     = "sns.amazonaws.com"


### PR DESCRIPTION
A possible code tidy I spotted while reviewing #76 – Terraform lets you pass a `name_prefix` instead of a `name`, thus saving us a bit of code to generate random suffixes.