### PR TITLE
Introduces new variables to pass on to the EFS modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor 
+
+Fix computed map issue for rds

--- a/efs/main.tf
+++ b/efs/main.tf
@@ -10,7 +10,7 @@ resource "aws_efs_file_system" "efs" {
 }
 
 resource "aws_efs_mount_target" "mount_target" {
-  count           = "${length(var.subnets)}"
+  count           = "${var.num_subnets}"
   file_system_id  = "${aws_efs_file_system.efs.id}"
   subnet_id       = "${var.subnets[count.index]}"
   security_groups = ["${aws_security_group.efs_mnt.id}"]

--- a/efs/variables.tf
+++ b/efs/variables.tf
@@ -20,3 +20,7 @@ variable "performance_mode" {
   description = "EFS Performance mode (generalPurpose or maxIO)"
   default     = "generalPurpose"
 }
+
+variable "num_subnets" {
+  description = "Number of subnets"
+}

--- a/network/outputs.tf
+++ b/network/outputs.tf
@@ -9,3 +9,7 @@ output "public_subnets" {
 output "vpc_id" {
   value = "${aws_vpc.vpc.id}"
 }
+
+output "num_subnets" {
+  value = "${var.az_count}"
+}


### PR DESCRIPTION
This introduces new variables to pass on to the EFS modules, so that the number of mount targets to create is not derived from a computed value which might not yet be available. This is a possible workaround to issue #83 and is being used in https://github.com/wellcometrust/workflow/tree/new-infra