### PR TITLE
Reintroduce env_vars_length

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor 
+
+Force specifying number of environment variavles when passing them to tasks

--- a/autoscaling/app/ecs/main.tf
+++ b/autoscaling/app/ecs/main.tf
@@ -40,7 +40,7 @@ resource "aws_appautoscaling_policy" "scale_down" {
 
 resource "aws_appautoscaling_target" "service_scale_target" {
   service_namespace  = "ecs"
-  resource_id        = "service/${var.cluster_name}/${var.service_name}"
+  resource_id        = "${local.resource_id}"
   scalable_dimension = "ecs:service:DesiredCount"
   role_arn           = "${aws_iam_role.ecs_autoscale_role.arn}"
 

--- a/ecs/modules/service/prebuilt/sqs_scaling/main.tf
+++ b/ecs/modules/service/prebuilt/sqs_scaling/main.tf
@@ -53,7 +53,7 @@ module "task" {
   memory = "${var.memory}"
   cpu    = "${var.cpu}"
 
-  env_vars = "${var.env_vars}"
+  env_vars        = "${var.env_vars}"
   env_vars_length = "${var.env_vars_length}"
 
   aws_region = "${var.aws_region}"

--- a/ecs/modules/service/prebuilt/sqs_scaling/main.tf
+++ b/ecs/modules/service/prebuilt/sqs_scaling/main.tf
@@ -54,6 +54,7 @@ module "task" {
   cpu    = "${var.cpu}"
 
   env_vars = "${var.env_vars}"
+  env_vars_length = "${var.env_vars_length}"
 
   aws_region = "${var.aws_region}"
 }

--- a/ecs/modules/service/prebuilt/sqs_scaling/variables.tf
+++ b/ecs/modules/service/prebuilt/sqs_scaling/variables.tf
@@ -76,3 +76,6 @@ variable "security_group_ids" {
 variable "namespace_id" {
   default = "ecs"
 }
+variable "env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/service/prebuilt/sqs_scaling/variables.tf
+++ b/ecs/modules/service/prebuilt/sqs_scaling/variables.tf
@@ -76,6 +76,7 @@ variable "security_group_ids" {
 variable "namespace_id" {
   default = "ecs"
 }
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
+++ b/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
@@ -56,7 +56,8 @@ module "sidecar_log_group" {
 
 module "sidecar_env_vars" {
   source   = "../../env_vars"
-  env_vars = "${var.app_env_vars}"
+  env_vars = "${var.sidecar_env_vars}"
+  env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
 # App
@@ -69,4 +70,5 @@ module "app_log_group" {
 module "app_env_vars" {
   source   = "../../env_vars"
   env_vars = "${var.app_env_vars}"
+  env_vars_length = "${var.app_env_vars_length}"
 }

--- a/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
+++ b/ecs/modules/task/modules/container_definition/container_with_sidecar/main.tf
@@ -55,8 +55,8 @@ module "sidecar_log_group" {
 }
 
 module "sidecar_env_vars" {
-  source   = "../../env_vars"
-  env_vars = "${var.sidecar_env_vars}"
+  source          = "../../env_vars"
+  env_vars        = "${var.sidecar_env_vars}"
   env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
@@ -68,7 +68,7 @@ module "app_log_group" {
 }
 
 module "app_env_vars" {
-  source   = "../../env_vars"
-  env_vars = "${var.app_env_vars}"
+  source          = "../../env_vars"
+  env_vars        = "${var.app_env_vars}"
   env_vars_length = "${var.app_env_vars_length}"
 }

--- a/ecs/modules/task/modules/container_definition/container_with_sidecar/variables.tf
+++ b/ecs/modules/task/modules/container_definition/container_with_sidecar/variables.tf
@@ -29,6 +29,10 @@ variable "app_env_vars" {
   default     = {}
 }
 
+variable "sidecar_env_vars_length" {
+  default = 0
+}
+
 # Sidecar
 
 variable "sidecar_container_image" {}
@@ -49,4 +53,8 @@ variable "sidecar_env_vars" {
   description = "Environment variables to pass to the container"
   type        = "map"
   default     = {}
+}
+
+variable "app_env_vars_length" {
+  default = 0
 }

--- a/ecs/modules/task/modules/container_definition/single_container/main.tf
+++ b/ecs/modules/task/modules/container_definition/single_container/main.tf
@@ -41,4 +41,5 @@ module "env_vars" {
   source = "../../env_vars"
 
   env_vars = "${var.env_vars}"
+  env_vars_length = "${var.env_vars_length}"
 }

--- a/ecs/modules/task/modules/container_definition/single_container/main.tf
+++ b/ecs/modules/task/modules/container_definition/single_container/main.tf
@@ -40,6 +40,6 @@ module "log_group" {
 module "env_vars" {
   source = "../../env_vars"
 
-  env_vars = "${var.env_vars}"
+  env_vars        = "${var.env_vars}"
   env_vars_length = "${var.env_vars_length}"
 }

--- a/ecs/modules/task/modules/container_definition/single_container/variables.tf
+++ b/ecs/modules/task/modules/container_definition/single_container/variables.tf
@@ -26,3 +26,7 @@ variable "mount_points" {
   type    = "list"
   default = []
 }
+
+variable "env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/modules/env_vars/main.tf
+++ b/ecs/modules/task/modules/env_vars/main.tf
@@ -47,7 +47,7 @@
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
-  count    = "${length(var.env_vars)}"
+  count    = "${var.env_vars_length}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/ecs/modules/task/modules/env_vars/main.tf
+++ b/ecs/modules/task/modules/env_vars/main.tf
@@ -56,7 +56,8 @@ data "template_file" "name_val_pair" {
   // from terraform resource types).
   //
   // TODO compute count once those issues are closed
-  count    = "${var.env_vars_length}"
+  count = "${var.env_vars_length}"
+
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 
   vars {

--- a/ecs/modules/task/modules/env_vars/main.tf
+++ b/ecs/modules/task/modules/env_vars/main.tf
@@ -47,6 +47,15 @@
 # docs: https://www.terraform.io/docs/configuration/interpolation.html
 
 data "template_file" "name_val_pair" {
+  // According to hashicorp/terraform#17287 and hashicorp/terraform#14677 length can only
+  // be calculated for not computed values. If a map or list contains computed values,
+  // the whole map is considered as computed.
+  //
+  // This means the way we pass environment variables at the moment only works if there
+  // are no computed values (i.e. outputs from modules or outputs
+  // from terraform resource types).
+  //
+  // TODO compute count once those issues are closed
   count    = "${var.env_vars_length}"
   template = "{\"name\": $${jsonencode(key)}, \"value\": $${jsonencode(value)}}"
 

--- a/ecs/modules/task/modules/env_vars/variables.tf
+++ b/ecs/modules/task/modules/env_vars/variables.tf
@@ -3,5 +3,4 @@ variable "env_vars" {
   type        = "map"
 }
 
-variable "env_vars_length" {
-}
+variable "env_vars_length" {}

--- a/ecs/modules/task/modules/env_vars/variables.tf
+++ b/ecs/modules/task/modules/env_vars/variables.tf
@@ -1,5 +1,7 @@
 variable "env_vars" {
   description = "Environment variables to pass to the container"
   type        = "map"
-  default     = {}
+}
+
+variable "env_vars_length" {
 }

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/main.tf
@@ -24,7 +24,7 @@ module "container_definition" {
   sidecar_cpu      = "${var.sidecar_cpu}"
   sidecar_env_vars = "${var.sidecar_env_vars}"
 
-  app_env_vars_length = "${var.app_env_vars_length}"
+  app_env_vars_length     = "${var.app_env_vars_length}"
   sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/main.tf
@@ -23,6 +23,9 @@ module "container_definition" {
   sidecar_memory   = "${var.sidecar_memory}"
   sidecar_cpu      = "${var.sidecar_cpu}"
   sidecar_env_vars = "${var.sidecar_env_vars}"
+
+  app_env_vars_length = "${var.app_env_vars_length}"
+  sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/variables.tf
@@ -41,3 +41,9 @@ variable "ebs_container_path" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+variable "app_env_vars_length" {
+  default = 0
+}
+variable "sidecar_env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs+efs/variables.tf
@@ -41,9 +41,11 @@ variable "ebs_container_path" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+
 variable "app_env_vars_length" {
   default = 0
 }
+
 variable "sidecar_env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs/main.tf
@@ -20,10 +20,10 @@ module "container_definition" {
   sidecar_container_image      = "${var.sidecar_container_image}"
   sidecar_port_mappings_string = "${module.sidecar_port_mappings.port_mappings_string}"
 
-  sidecar_memory   = "${var.sidecar_memory}"
-  sidecar_cpu      = "${var.sidecar_cpu}"
-  sidecar_env_vars = "${var.sidecar_env_vars}"
-  app_env_vars_length = "${var.app_env_vars_length}"
+  sidecar_memory          = "${var.sidecar_memory}"
+  sidecar_cpu             = "${var.sidecar_cpu}"
+  sidecar_env_vars        = "${var.sidecar_env_vars}"
+  app_env_vars_length     = "${var.app_env_vars_length}"
   sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs/main.tf
@@ -23,6 +23,8 @@ module "container_definition" {
   sidecar_memory   = "${var.sidecar_memory}"
   sidecar_cpu      = "${var.sidecar_cpu}"
   sidecar_env_vars = "${var.sidecar_env_vars}"
+  app_env_vars_length = "${var.app_env_vars_length}"
+  sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs/variables.tf
@@ -38,9 +38,11 @@ variable "aws_region" {}
 
 variable "ebs_host_path" {}
 variable "ebs_container_path" {}
+
 variable "app_env_vars_length" {
   default = 0
 }
+
 variable "sidecar_env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/container_with_sidecar+ebs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+ebs/variables.tf
@@ -38,3 +38,9 @@ variable "aws_region" {}
 
 variable "ebs_host_path" {}
 variable "ebs_container_path" {}
+variable "app_env_vars_length" {
+  default = 0
+}
+variable "sidecar_env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/container_with_sidecar+efs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+efs/main.tf
@@ -24,7 +24,7 @@ module "container_definition" {
   sidecar_cpu      = "${var.sidecar_cpu}"
   sidecar_env_vars = "${var.sidecar_env_vars}"
 
-  app_env_vars_length = "${var.app_env_vars_length}"
+  app_env_vars_length     = "${var.app_env_vars_length}"
   sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/container_with_sidecar+efs/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+efs/main.tf
@@ -23,6 +23,9 @@ module "container_definition" {
   sidecar_memory   = "${var.sidecar_memory}"
   sidecar_cpu      = "${var.sidecar_cpu}"
   sidecar_env_vars = "${var.sidecar_env_vars}"
+
+  app_env_vars_length = "${var.app_env_vars_length}"
+  sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/container_with_sidecar+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+efs/variables.tf
@@ -38,3 +38,9 @@ variable "aws_region" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+variable "app_env_vars_length" {
+  default = 0
+}
+variable "sidecar_env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/container_with_sidecar+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar+efs/variables.tf
@@ -38,9 +38,11 @@ variable "aws_region" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+
 variable "app_env_vars_length" {
   default = 0
 }
+
 variable "sidecar_env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
@@ -21,7 +21,7 @@ module "container_definition" {
   sidecar_port_mappings_string = "${module.sidecar_port_mappings.port_mappings_string}"
   sidecar_env_vars             = "${var.sidecar_env_vars}"
 
-  app_env_vars_length = "${var.app_env_vars_length}"
+  app_env_vars_length     = "${var.app_env_vars_length}"
   sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar/main.tf
@@ -20,6 +20,9 @@ module "container_definition" {
   sidecar_container_image      = "${var.sidecar_container_image}"
   sidecar_port_mappings_string = "${module.sidecar_port_mappings.port_mappings_string}"
   sidecar_env_vars             = "${var.sidecar_env_vars}"
+
+  app_env_vars_length = "${var.app_env_vars_length}"
+  sidecar_env_vars_length = "${var.sidecar_env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
@@ -35,9 +35,11 @@ variable "sidecar_is_proxy" {
 }
 
 variable "aws_region" {}
+
 variable "app_env_vars_length" {
   default = 0
 }
+
 variable "sidecar_env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
+++ b/ecs/modules/task/prebuilt/container_with_sidecar/variables.tf
@@ -35,3 +35,9 @@ variable "sidecar_is_proxy" {
 }
 
 variable "aws_region" {}
+variable "app_env_vars_length" {
+  default = 0
+}
+variable "sidecar_env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/single_container+ebs+efs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs+efs/main.tf
@@ -16,7 +16,7 @@ module "container_definition" {
 
   mount_points = "${module.task_definition.mount_points}"
 
-  task_port = "${var.container_port}"
+  task_port       = "${var.container_port}"
   env_vars_length = "${var.env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/single_container+ebs+efs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs+efs/main.tf
@@ -17,6 +17,7 @@ module "container_definition" {
   mount_points = "${module.task_definition.mount_points}"
 
   task_port = "${var.container_port}"
+  env_vars_length = "${var.env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/single_container+ebs+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs+efs/variables.tf
@@ -32,3 +32,6 @@ variable "ebs_container_path" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+variable "env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/single_container+ebs+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs+efs/variables.tf
@@ -32,6 +32,7 @@ variable "ebs_container_path" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/single_container+ebs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs/main.tf
@@ -16,7 +16,7 @@ module "container_definition" {
 
   mount_points = "${module.task_definition.mount_points}"
 
-  task_port = "${var.container_port}"
+  task_port       = "${var.container_port}"
   env_vars_length = "${var.env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/single_container+ebs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs/main.tf
@@ -17,6 +17,7 @@ module "container_definition" {
   mount_points = "${module.task_definition.mount_points}"
 
   task_port = "${var.container_port}"
+  env_vars_length = "${var.env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/single_container+ebs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs/variables.tf
@@ -29,6 +29,7 @@ variable "aws_region" {}
 
 variable "ebs_host_path" {}
 variable "ebs_container_path" {}
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/single_container+ebs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+ebs/variables.tf
@@ -29,3 +29,6 @@ variable "aws_region" {}
 
 variable "ebs_host_path" {}
 variable "ebs_container_path" {}
+variable "env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/single_container+efs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+efs/main.tf
@@ -16,7 +16,7 @@ module "container_definition" {
 
   mount_points = "${module.task_definition.mount_points}"
 
-  task_port = "${var.container_port}"
+  task_port       = "${var.container_port}"
   env_vars_length = "${var.env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/single_container+efs/main.tf
+++ b/ecs/modules/task/prebuilt/single_container+efs/main.tf
@@ -17,6 +17,7 @@ module "container_definition" {
   mount_points = "${module.task_definition.mount_points}"
 
   task_port = "${var.container_port}"
+  env_vars_length = "${var.env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/single_container+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+efs/variables.tf
@@ -29,3 +29,6 @@ variable "aws_region" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+variable "env_vars_length" {
+  default = 0
+}

--- a/ecs/modules/task/prebuilt/single_container+efs/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container+efs/variables.tf
@@ -29,6 +29,7 @@ variable "aws_region" {}
 
 variable "efs_host_path" {}
 variable "efs_container_path" {}
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/single_container/main.tf
+++ b/ecs/modules/task/prebuilt/single_container/main.tf
@@ -15,6 +15,8 @@ module "container_definition" {
   memory = "${var.memory}"
 
   task_port = "${var.container_port}"
+
+  env_vars_length = "${var.env_vars_length}"
 }
 
 module "task_definition" {

--- a/ecs/modules/task/prebuilt/single_container/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container/variables.tf
@@ -26,6 +26,7 @@ variable "memory" {
 }
 
 variable "aws_region" {}
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/single_container/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container/variables.tf
@@ -26,3 +26,6 @@ variable "memory" {
 }
 
 variable "aws_region" {}
+variable "env_vars_length" {
+  default = 0
+}


### PR DESCRIPTION
According to https://github.com/hashicorp/terraform/issues/17287 and https://github.com/hashicorp/terraform/issues/14677 length can only be calculated for not computed values. If a map or list contains computed values, the whole map is considered as computed. 

This means the way we pass environment variables at the moment only works if there are no computed values (i.e. outputs from modules or outputs from terraform resource types).

So, reintroducing env_vars_length until terraform fixes this