### PR TITLE
Lambda module gains `invoke_arn` output

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,3 @@
 RELEASE_TYPE: minor
 
 This adds an output for the `lambda` module, so that the `invoke_arn` property of the `aws_lambda_function` can be integrated with API Gateway.
- 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: minor
+
+This adds an output for the `lambda` module, so that the `invoke_arn` property of the `aws_lambda_function` can be integrated with API Gateway.
+ 

--- a/lambda/outputs.tf
+++ b/lambda/outputs.tf
@@ -12,3 +12,8 @@ output "role_name" {
   description = "Name of the IAM role for this Lambda"
   value       = "${aws_iam_role.iam_role.name}"
 }
+
+output "invoke_arn" {
+  description = "The ARN to be used for invoking Lambda Function from API Gateway"
+  value       = "${aws_lambda_function.lambda_function.invoke_arn}"
+}


### PR DESCRIPTION
Adding `invoke_arn` attribute of `aws_lambda_function` resource to the outputs of the `lambda` module. This is to enable easy integration of API Gateway which requires this particular ARN for invocation.