### PR TITLE
Remove reference to data element, when resource will do

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch 
+
+Fix a bug with calling a data block instead of resource for ecs iam roles

--- a/ecs/modules/task/modules/iam_roles/main.tf
+++ b/ecs/modules/task/modules/iam_roles/main.tf
@@ -42,7 +42,3 @@ data "aws_iam_policy_document" "task_execution_role" {
     ]
   }
 }
-
-data "aws_iam_role" "task_role" {
-  name = "${aws_iam_role.task_role.name}"
-}

--- a/ecs/modules/task/modules/iam_roles/outputs.tf
+++ b/ecs/modules/task/modules/iam_roles/outputs.tf
@@ -3,7 +3,7 @@ output "name" {
 }
 
 output "task_role_arn" {
-  value = "${data.aws_iam_role.task_role.arn}"
+  value = "${aws_iam_role.task_role..arn}"
 }
 
 output "task_execution_role_arn" {

--- a/ecs/modules/task/modules/iam_roles/outputs.tf
+++ b/ecs/modules/task/modules/iam_roles/outputs.tf
@@ -3,7 +3,7 @@ output "name" {
 }
 
 output "task_role_arn" {
-  value = "${aws_iam_role.task_role..arn}"
+  value = "${aws_iam_role.task_role.arn}"
 }
 
 output "task_execution_role_arn" {


### PR DESCRIPTION
It seems in the most recent versions of terraform have caused plans to start failing as the data block refers to resources that do not yet exist. 

This removes the indirect reference and seems to resolve the issue.