### PR TITLE
Expose mount points and command

### DIFF
--- a/ecs/modules/task/modules/container_definition/single_container/main.tf
+++ b/ecs/modules/task/modules/container_definition/single_container/main.tf
@@ -2,6 +2,7 @@ locals {
   mount_points   = "${jsonencode(var.mount_points)}"
   log_group_name = "${var.task_name}"
   container_name = "app"
+  command        = "${jsonencode(var.command)}"
 }
 
 data "template_file" "definition" {
@@ -17,6 +18,8 @@ data "template_file" "definition" {
 
     port_mappings    = "${module.port_mappings.port_mappings_string}"
     environment_vars = "${module.env_vars.env_vars_string}"
+
+    command = "${local.command}"
 
     cpu    = "${var.cpu}"
     memory = "${var.memory}"

--- a/ecs/modules/task/modules/container_definition/single_container/task_definition.json.template
+++ b/ecs/modules/task/modules/container_definition/single_container/task_definition.json.template
@@ -8,6 +8,7 @@
     "environment": ${environment_vars},
     "networkMode": "awsvpc",
     "portMappings": ${port_mappings},
+    "command": ${command}
     "logConfiguration": {
         "logDriver": "awslogs",
         "options": {

--- a/ecs/modules/task/modules/container_definition/single_container/variables.tf
+++ b/ecs/modules/task/modules/container_definition/single_container/variables.tf
@@ -27,6 +27,11 @@ variable "mount_points" {
   default = []
 }
 
+variable "command" {
+  type    = "list"
+  default = []
+}
+
 variable "env_vars_length" {
   default = 0
 }

--- a/ecs/modules/task/prebuilt/single_container/main.tf
+++ b/ecs/modules/task/prebuilt/single_container/main.tf
@@ -16,6 +16,9 @@ module "container_definition" {
 
   task_port = "${var.container_port}"
 
+  mount_points = "${var.mount_points}"
+  command      = "${var.command}"
+
   env_vars_length = "${var.env_vars_length}"
 }
 

--- a/ecs/modules/task/prebuilt/single_container/variables.tf
+++ b/ecs/modules/task/prebuilt/single_container/variables.tf
@@ -30,3 +30,13 @@ variable "aws_region" {}
 variable "env_vars_length" {
   default = 0
 }
+
+variable "mount_points" {
+  type    = "list"
+  default = []
+}
+
+variable "command" {
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
Allow `mount_points` and command` variables to be set in a container definition (available through the single_container prebuilt).