### PR TITLE
Default DNS hostnames

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch 
+
+enable_dns_hostnames by default

--- a/network/prebuilt/vpc/public-private-igw/main.tf
+++ b/network/prebuilt/vpc/public-private-igw/main.tf
@@ -1,6 +1,9 @@
 resource "aws_vpc" "vpc" {
   cidr_block = "${var.cidr_block_vpc}"
 
+  enable_dns_support = "${var.enable_dns_support}"
+  enable_dns_hostnames = "${var.enable_dns_hostnames}"
+
   tags {
     Name = "${var.name}"
   }

--- a/network/prebuilt/vpc/public-private-igw/main.tf
+++ b/network/prebuilt/vpc/public-private-igw/main.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc" "vpc" {
   cidr_block = "${var.cidr_block_vpc}"
 
-  enable_dns_support = "${var.enable_dns_support}"
+  enable_dns_support   = "${var.enable_dns_support}"
   enable_dns_hostnames = "${var.enable_dns_hostnames}"
 
   tags {

--- a/network/prebuilt/vpc/public-private-igw/variables.tf
+++ b/network/prebuilt/vpc/public-private-igw/variables.tf
@@ -14,6 +14,7 @@ variable "private_az_count" {}
 variable "enable_dns_support" {
   default = true
 }
+
 variable "enable_dns_hostnames" {
   default = true
 }

--- a/network/prebuilt/vpc/public-private-igw/variables.tf
+++ b/network/prebuilt/vpc/public-private-igw/variables.tf
@@ -8,10 +8,12 @@ variable "cidr_block_private" {}
 variable "cidrsubnet_newbits_public" {}
 variable "cidrsubnet_newbits_private" {}
 
-variable "public_az_count" {
-  default = ""
-}
+variable "public_az_count" {}
+variable "private_az_count" {}
 
-variable "private_az_count" {
-  default = ""
+variable "enable_dns_support" {
+  default = true
+}
+variable "enable_dns_hostnames" {
+  default = true
 }


### PR DESCRIPTION
Set default for prebuilt VPC module enable_dns_hostnames to true
In order that service discovery works as expected