### PR TITLE
Allow omitting the SSH key name in the prebuilt EC2 modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Allow omitting the `key_name` variable in the prebuilt EC2 modules (if you're not allowing SSH access to the instances).

--- a/ecs/modules/ec2/prebuilt/ebs+efs/variables.tf
+++ b/ecs/modules/ec2/prebuilt/ebs+efs/variables.tf
@@ -29,10 +29,14 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-c91624b0"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {

--- a/ecs/modules/ec2/prebuilt/ebs/variables.tf
+++ b/ecs/modules/ec2/prebuilt/ebs/variables.tf
@@ -29,10 +29,14 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-c91624b0"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {

--- a/ecs/modules/ec2/prebuilt/efs/variables.tf
+++ b/ecs/modules/ec2/prebuilt/efs/variables.tf
@@ -29,10 +29,14 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-c91624b0"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {

--- a/ecs/modules/ec2/prebuilt/nvm/variables.tf
+++ b/ecs/modules/ec2/prebuilt/nvm/variables.tf
@@ -24,7 +24,6 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-0627e141ce928067c"
@@ -32,6 +31,11 @@ variable "image_id" {
 
 variable "instance_type" {
   default = "i3.2xlarge"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {

--- a/ecs/modules/ec2/prebuilt/ondemand/variables.tf
+++ b/ecs/modules/ec2/prebuilt/ondemand/variables.tf
@@ -29,10 +29,14 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-c91624b0"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {

--- a/ecs/modules/ec2/prebuilt/spot/variables.tf
+++ b/ecs/modules/ec2/prebuilt/spot/variables.tf
@@ -29,10 +29,14 @@ variable "subnets" {
 }
 
 variable "vpc_id" {}
-variable "key_name" {}
 
 variable "image_id" {
   default = "ami-c91624b0"
+}
+
+variable "key_name" {
+  description = "SSH key name for SSH access.  Leave blank if not using SSH."
+  default     = ""
 }
 
 variable "controlled_access_cidr_ingress" {


### PR DESCRIPTION
I don’t think we want it all the time – in some cases (e.g. Loris), we don’t allow SSH access to the instances, so specifying a key is pointless.