### PR TITLE
add cross account access to SNS topics

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Add cross account access permissions to be set for SNS topics

--- a/sns/cross_account_topic_policy.tf
+++ b/sns/cross_account_topic_policy.tf
@@ -1,0 +1,70 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_sns_topic_policy" "cross_account_topic_subscription_policy" {
+  count  = "${length(var.cross_account_subscription_ids) > 0 ? 1 : 0}"
+  arn    = "${aws_sns_topic.topic.arn}"
+  policy = "${data.aws_iam_policy_document.cross_account_sns_topic_policy.json}"
+}
+
+data "aws_iam_policy_document" "cross_account_sns_topic_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        "${data.aws_caller_identity.current.account_id}",
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${aws_sns_topic.topic.arn}",
+    ]
+
+    sid = "__default_statement_ID"
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:Receive",
+      "SNS:GetTopicAttributes",
+      "SNS:SetTopicAttributes",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = "${formatlist("arn:aws:iam::%s:root", var.cross_account_subscription_ids)}"
+    }
+
+    resources = [
+      "${aws_sns_topic.topic.arn}",
+    ]
+
+    sid = "ReportingAccess"
+  }
+}

--- a/sns/variables.tf
+++ b/sns/variables.tf
@@ -1,3 +1,9 @@
 variable "name" {
   description = "Name of the SNS topic"
 }
+
+variable "cross_account_subscription_ids" {
+  type        = "list"
+  default     = []
+  description = "AWS account IDs alolowed to subscribe to this topic"
+}


### PR DESCRIPTION
As out topics are spread between accounts (currently `catalogue` and `platform`) this becomes useful to allow other accounts to hook onto these topics, namely, `reporting`.

Because it affects more than 1 repo, it felt like generalising was better than copy / pasting into both repos.

Even if we start being more idealistic and putting these topics in their right repos and accounts, this will probably be needed.

The implementation is non-breaking.